### PR TITLE
Update ram_modules.md

### DIFF
--- a/ram_modules.md
+++ b/ram_modules.md
@@ -31,6 +31,7 @@
 - Samsung 16GB DDR4-2400 CL17 M471A2K43CB1-CRC ([1](https://www.mydealz.de/comments/permalink/37675240), [2](https://www.mydealz.de/comments/permalink/37775352), [3](https://www.mydealz.de/comments/permalink/37812712)) (funktioniert evtl. erst nach BIOS Update)  
 - Samsung 16GB DDR4-2666 CL19 M471A2K43CB1-CTD ([1](https://www.mydealz.de/comments/permalink/37675240), [2](https://www.mydealz.de/comments/permalink/37737205), [3](https://www.mydealz.de/comments/permalink/38169890), [4](https://www.mydealz.de/comments/permalink/38173450))  
 - Samsung 16GB DDR4-2666 CL19 M471A2K43DB1-CTD ([1](https://www.mydealz.de/comments/permalink/37675240))  
+- Samsung 16GB DDR4-3200 CL22 M471A2K43DB1-CWE
 
 ## Kimtigo
 - Kimtigo 16GB DDR4-2666 KMKS16GF68-2666V ([1](https://www.mydealz.de/comments/permalink/37675240))  


### PR DESCRIPTION
`# dmidecode 3.3
Getting SMBIOS data from sysfs.
SMBIOS 3.1.1 present.

Handle 0x0020, DMI type 17, 40 bytes
Memory Device
Array Handle: 0x001E
Error Information Handle: Not Provided
Total Width: 64 bits
Data Width: 64 bits
Size: 16 GB
Form Factor: SODIMM
Set: None
Locator: A1_DIMM0
Bank Locator: A1_BANK0
Type: DDR4
Type Detail: Synchronous
Speed: 2400 MT/s
Manufacturer: Samsung
Serial Number: xxxxxxxx
Asset Tag: 9876543210
Part Number: M471A2K43DB1-CWE
Rank: Unknown
Configured Memory Speed: 2400 MT/s
Minimum Voltage: 1.5 V
Maximum Voltage: 1.5 V
Configured Voltage: 1.2 V`