### PR TITLE
Update ram_modules.md: neu Crucial CT16G4SFRA32A.M8FF

### DIFF
--- a/ram_modules.md
+++ b/ram_modules.md
@@ -57,6 +57,7 @@
 - Crucial 32GB Ballistix DDR4-3200 - BL2K32G32C16S4B ([1](https://www.mydealz.de/comments/permalink/37621382))  
 - Crucial 16GB DDR4-2666 CT16G4SFRA266 ([es gibt 2 Ausführungen](https://www.mydealz.de/comments/permalink/37675998)!!!) ([1](https://www.mydealz.de/comments/permalink/37684741), [2](https://www.mydealz.de/comments/permalink/37684700), [3](https://www.mydealz.de/comments/permalink/37702741))
 - Crucial 16GB DDR4-3200 CT16G4SFRA32A.C8FF ([1](https://github.com/R3NE07/Futro-S740/pull/10), [2](https://github.com/R3NE07/Futro-S740/pull/13#issue-1556960486), [3](https://github.com/R3NE07/Futro-S740/issues/9#issue-1506966280))  
+- Crucial 16GB DDR4-3200 CT16G4SFRA32A.M8FF ([1](https://www.mydealz.de/comments/permalink/41354552))  
 - Crucial 32GB DDR4-2666 CT32G4SFD8266 ([1](https://www.mydealz.de/comments/permalink/37671092), [2](https://www.mydealz.de/comments/permalink/37835112))  
 - Crucial 32GB DDR4-3200 CT32G4SFD832A ([1](https://www.mydealz.de/comments/permalink/37660073), [2](https://www.mydealz.de/comments/permalink/37660093))  
 


### PR DESCRIPTION
Vom 16GB RAM-Modul "Crucial CT16G4SFRA32A" gibt es neben den 3 bisher eingetragenen Sub-Typen (C16F, M16FR, C8FF) offenbar noch einen 4. Sub-Typ M8FF - also ein Modul "Crucial CT16G4SFRA32A.M8FF".
Dieses Modul funktioniert offenbar leider nicht, siehe https://www.mydealz.de/comments/permalink/41354552