### PR TITLE
Added CT16G4SFRA32A.M16FR and CT16G4SFRA32A.C16FN to compatible RAM modules

### DIFF
--- a/ram_modules.md
+++ b/ram_modules.md
@@ -18,8 +18,8 @@
 - Crucial 16GB DDR4-2400 CL17 CT16G4SFD824A.C16F ([1](https://www.mydealz.de/deals/refurbished-fujitsu-futro-s740-raspberry-pi-alternative-2041563#reply-37758713))  
 - Crucial 16GB DDR4-2666 CL19 CT16G4SFRA266 ([es gibt 2 Ausführungen](https://www.mydealz.de/deals/refurbished-fujitsu-futro-s740-raspberry-pi-alternative-2041563#reply-37675998)) ([1](https://www.mydealz.de/deals/fujitsu-q5562-mini-pc-4gb-ram-intel-g4400t-cpu-ohne-ssd-als-raspberry-alternative-fur-smarthome-server-ebay-refurbished-2038281#reply-37454722), [2](https://www.mydealz.de/deals/refurbished-fujitsu-futro-s740-raspberry-pi-alternative-2041563#reply-37657476), [3](https://www.mydealz.de/deals/refurbished-fujitsu-futro-s740-raspberry-pi-alternative-2041563#reply-37674082), [4](https://www.mydealz.de/deals/refurbished-fujitsu-futro-s740-raspberry-pi-alternative-2041563#reply-37710822))  
 - Crucial 16GB DDR4-3200 CL22 CT16G4SFRA32A.C16F
-- Crucial 16GB DDR4-3200 CL22 CT16G4SFRA32A.C16FN
-- Crucial 16GB DDR4-3200 CL22 CT16G4SFRA32A.M16FE
+- Crucial 16GB DDR4-3200 CL22 CT16G4SFRA32A.C16FN ([1](https://github.com/R3NE07/Futro-S740/pull/60))
+- Crucial 16GB DDR4-3200 CL22 CT16G4SFRA32A.M16FE ([1](https://github.com/R3NE07/Futro-S740/pull/60))
 - Crucial 16GB DDR4-3200 CL22 CT16G4SFRA32A.M16FR ([1](https://www.mydealz.de/deals/refurbished-fujitsu-futro-s740-raspberry-pi-alternative-2041563#comment-38300891))  
 
 ## Micron

--- a/ram_modules.md
+++ b/ram_modules.md
@@ -17,7 +17,9 @@
 - Crucial 16GB DDR4-2400 CL17 CT16G4SFD824A.M16FRS  
 - Crucial 16GB DDR4-2400 CL17 CT16G4SFD824A.C16F ([1](https://www.mydealz.de/deals/refurbished-fujitsu-futro-s740-raspberry-pi-alternative-2041563#reply-37758713))  
 - Crucial 16GB DDR4-2666 CL19 CT16G4SFRA266 ([es gibt 2 Ausführungen](https://www.mydealz.de/deals/refurbished-fujitsu-futro-s740-raspberry-pi-alternative-2041563#reply-37675998)) ([1](https://www.mydealz.de/deals/fujitsu-q5562-mini-pc-4gb-ram-intel-g4400t-cpu-ohne-ssd-als-raspberry-alternative-fur-smarthome-server-ebay-refurbished-2038281#reply-37454722), [2](https://www.mydealz.de/deals/refurbished-fujitsu-futro-s740-raspberry-pi-alternative-2041563#reply-37657476), [3](https://www.mydealz.de/deals/refurbished-fujitsu-futro-s740-raspberry-pi-alternative-2041563#reply-37674082), [4](https://www.mydealz.de/deals/refurbished-fujitsu-futro-s740-raspberry-pi-alternative-2041563#reply-37710822))  
-- Crucial 16GB DDR4-3200 CL22 CT16G4SFRA32A.C16F  
+- Crucial 16GB DDR4-3200 CL22 CT16G4SFRA32A.C16F
+- Crucial 16GB DDR4-3200 CL22 CT16G4SFRA32A.C16FN
+- Crucial 16GB DDR4-3200 CL22 CT16G4SFRA32A.M16FE
 - Crucial 16GB DDR4-3200 CL22 CT16G4SFRA32A.M16FR ([1](https://www.mydealz.de/deals/refurbished-fujitsu-futro-s740-raspberry-pi-alternative-2041563#comment-38300891))  
 
 ## Micron


### PR DESCRIPTION
I have successfully tested the following RAM modules in the Futro S740
- Crucial 16GB DDR4-3200 CL22 CT16G4SFRA32A.C16FN
- Crucial 16GB DDR4-3200 CL22 CT16G4SFRA32A.M16FE